### PR TITLE
Closing of the call route to ARIA by disabling the button to forward the services and displaying: "No call available for canSERV, 'Apply through ...' 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "molgenis-app-canserv-explorer",
   "license": "LGPL-3.0",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Vue application for the CanSERV service explorer; A card detail view on BBMRI-ERIC service providers / service data. Based on molgenis-app-biobank-explorer version 7.20.0",
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/popovers/NegotiatorSelection.vue
+++ b/src/components/popovers/NegotiatorSelection.vue
@@ -72,21 +72,8 @@
       </div>
       <!-- check if URL param "aria_pid" is present using this.$route.query
         if so, only display the button to forward to ARIA for this pid, otherwise display all available pids with info buttons form the website -->
-      <div class="ml-auto">
-        <b-button
-          :disabled="
-            (isPodium && !collectionsInPodium.length) ||
-            selectedCollections.length < 2
-          "
-          class="btn btn-secondary ml-auto"
-          @click="sendRequest3rdChallengeCall">{{ negotiatorChallengeCall3ButtonText }}
-        </b-button>
-        <button type="button" class="btn btn-primary" @click="openInNewTab('https://www.canserv.eu/calls/challenge-call-revolutionising-cancer-care/')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info-square" viewBox="0 0 16 16">
-                  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
-                  <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"></path>
-                </svg>
-        </button>
+      <div class="ml-auto text-white font-weight-bold d-block" style="font-weight: bold;font-size: large;">
+        There is no call open at the moment by canSERV.
       </div>
     </template>
   </b-modal>


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Added to release notes
